### PR TITLE
Update to be compatible with guard 2

### DIFF
--- a/lib/guard/elixir.rb
+++ b/lib/guard/elixir.rb
@@ -1,11 +1,8 @@
-require 'guard'
-require 'guard/guard'
-require 'guard/watcher'
-require 'guard/notifier'
+require "guard/compat/plugin"
 
 module Guard
-  class Elixir < Guard
-    def initialize(watchers=[], options={})
+  class Elixir < Plugin
+    def initialize(options={})
       super
       @options = {
         all_on_start: true,


### PR DESCRIPTION
https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#guardguard-deprecated-in-favor-of-guardplugin
